### PR TITLE
docfix: quick_start error

### DIFF
--- a/docs/quick_start/step2.ipynb
+++ b/docs/quick_start/step2.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "4. alice配置上传密钥信息，请在cli.yaml文件中手动配置。\n",
     "\n",
-    "- `resource_uris`：我们给加密数据取一个名称，在后面授权的时候会用到。比如，我们把这份数据叫做`breaset_cancer_alice`。这个名称后续会用到。\n",
+    "- `resource_uris`：我们给加密数据取一个名称，在后面授权的时候会用到。比如，我们把这份数据叫做`breast_cancer_alice`。这个名称后续会用到。\n",
     "- `data_key_b64s`：填写上一步得到的数据加密密钥。\n",
     "\n",
     "```yaml\n",

--- a/docs/quick_start/step2.ipynb
+++ b/docs/quick_start/step2.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "2. alice获取自身的机构ID，机构ID是一个BASE32编码的客户端公钥的哈希值，可以用以下命令生成。\n",
     "```bash\n",
-    "cms_util generate-party-id --cert-pems-file alice.crt\n",
+    "cms_util generate-party-id --cert-file alice.crt\n",
     "```\n",
     "\n",
     "3. alice配置party id、证书、私钥、加密算法等。\n",


### PR DESCRIPTION
quickstart 文档修复。
cms_util generate-party-id --cert-pems-file alice.crt 改为
cms_util generate-party-id --cert-file alice.crt