### PR TITLE
Fix: pypi publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
   pypi_publish:
     docker:
       - image: secretflow/trustedflow-dev-ubuntu22.04:latest
-    resource_class: large
+    resource_class: 2xlarge+
     parameters:
       python_ver:
         type: string

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ class BuildBazelExtension(build_ext.build_ext):
             + f" //{ext._bazel_workspace}:{ext._bazel_target}"
             + " --compilation_mode="
             + ("dbg" if self.debug else "opt")
-            + " --repository_cache=/tmp/bazel_repo_cache --remote_download_minimal"
+            + " --repository_cache=/tmp/bazel_repo_cache"
         )
         os.system(command)
 


### PR DESCRIPTION
1. pypi build need larger resource
2. --remote_download_minimal may cause generator.so and verifier.so be empty