### PR TITLE
docker: fix conda version in base images

### DIFF
--- a/docker/trustedflow-dev-ubuntu22.04.Dockerfile
+++ b/docker/trustedflow-dev-ubuntu22.04.Dockerfile
@@ -63,8 +63,8 @@ RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19
 
 
 # install conda
-RUN wget http://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-  && bash Miniconda3-latest-Linux-x86_64.sh -b && rm -f Miniconda3-latest-Linux-x86_64.sh \
+RUN wget http://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-Linux-x86_64.sh \
+  && bash Miniconda3-py310_24.4.0-0-Linux-x86_64.sh -b && rm -f Miniconda3-py310_24.4.0-0-Linux-x86_64.sh \
   && ln -sf /root/miniconda3/bin/conda /usr/bin/conda \
   && conda init
 

--- a/docker/trustedflow-release-ubuntu22.04.Dockerfile
+++ b/docker/trustedflow-release-ubuntu22.04.Dockerfile
@@ -25,8 +25,8 @@ RUN ln -sf /usr/bin/bash /bin/sh
 RUN apt update && apt install wget curl -y && apt clean
 
 # install conda
-RUN wget http://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-  && bash Miniconda3-latest-Linux-x86_64.sh -b && rm -f Miniconda3-latest-Linux-x86_64.sh \
+RUN wget http://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-Linux-x86_64.sh \
+  && bash Miniconda3-py310_24.4.0-0-Linux-x86_64.sh -b && rm -f Miniconda3-py310_24.4.0-0-Linux-x86_64.sh \
   && ln -sf /root/miniconda3/bin/conda /usr/bin/conda \
   && conda init
 


### PR DESCRIPTION
Miniconda3-latest's base env contains cryptography 41.0.7 and it has CVE-2023-50782

use Miniconda3-py310_24.4.0-0 instead