### PR TITLE
feat: Bump Intel DCAP to 1.23 to support TD quote generation via ConfigFS-TSM

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -144,11 +144,11 @@ def _com_github_dcap():
         http_archive,
         name = "dcap",
         urls = [
-            "https://github.com/intel/confidential-computing.tee.dcap/archive/refs/tags/DCAP_1.20.tar.gz",
+            "https://github.com/intel/confidential-computing.tee.dcap/archive/refs/tags/DCAP_1.23.tar.gz",
         ],
         build_file = "@trustflow//bazel:dcap.BUILD",
-        strip_prefix = "confidential-computing.tee.dcap-DCAP_1.20",
-        sha256 = "3a69a687f2222433addd25dfe6e54a6ca164fcbf4c3dec5ad9e8b155c5bb98cb",
+        strip_prefix = "confidential-computing.tee.dcap-DCAP_1.23",
+        sha256 = "9284ac7223f72daaeed8fb3c5bb3e4b1ccee6c2deafd0e7398c95c9fa50ffe8a",
     )
 
 def _com_gitee_hygon_csv_header():


### PR DESCRIPTION
This PR bumps the Intel DCAP library version from `1.20` to `1.23`.

### Background
Modern Linux kernels (specifically in TDX Guest environments; typically v6.7 or later) have shifted the TD Quote generation interface to the **ConfigFS-TSM** interface (see [Intel TDX DCAP QGL and QVL Documentation Rev 0.9 (pp. 7-10)](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_TDX_DCAP_Quoting_Library_API.pdf)).

The current version of DCAP used in TrustFlow (1.20) does not support ConfigFS-TSM; this support was introduced in DCAP 1.21 ([DCAP 1.21 Release Notes](https://github.com/intel/confidential-computing.tee.dcap/releases/tag/DCAP_1.21)).

As a result, generating TD Quotes fails on newer cloud environments, such as Google Cloud Platform's TDX instances, where the kernel enforces the use of ConfigFS and disables the legacy vsock interface.

### Dependencies
This PR depends on changes in #114. Please merge #114 first.

### Verification
I have verified that this upgrade resolves the Quote generation failure on the following GCP environment:
- **Platform:** Google Cloud Platform
- **Machine Type:** c3-standard-4 (Intel TDX enabled)
- **OS:** Ubuntu 24.04.1 LTS
- **Kernel:** 6.14.0-1019-gcp

### Before this change (DCAP 1.20)
Attestation report generation failed because the library could not interact with ConfigFS. It fell back to the vsock interface (which is unavailable in this environment), resulting in error `0x8`.

```console
[2025-11-19 09:27:02.556] [info] [tdx_generator.cc:83] Start generating tdx report

Error: Failed to generate report (YACL Exception)

  Message: [Enforce fail at external/trustflow/trustflow/attestation/generation/tdx/tdx_generator.cc:100] ret == tdx_attest_error_t::TDX_ATTEST_SUCCESS && p_quote_buf. tdx_att_get_quote err: 0x8
```

### After this change (DCAP 1.23)
The library correctly detects and utilizes the ConfigFS-TSM interface, and the TD Quote is generated successfully.

```console
[2025-11-19 11:35:52.968] [info] [tdx_generator.cc:83] Start generating tdx report
[2025-11-19 11:35:53.030] [info] [tdx_generator.cc:102] tdx_att_get_quote succeed
```
