### PR TITLE
fix + feat: DCAP v3.1+ collateral parsing and ConfigFS-TSM support

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -144,11 +144,11 @@ def _com_github_dcap():
         http_archive,
         name = "dcap",
         urls = [
-            "https://github.com/intel/confidential-computing.tee.dcap/archive/refs/tags/DCAP_1.20.tar.gz",
+            "https://github.com/intel/confidential-computing.tee.dcap/archive/refs/tags/DCAP_1.23.tar.gz",
         ],
         build_file = "@trustflow//bazel:dcap.BUILD",
-        strip_prefix = "confidential-computing.tee.dcap-DCAP_1.20",
-        sha256 = "3a69a687f2222433addd25dfe6e54a6ca164fcbf4c3dec5ad9e8b155c5bb98cb",
+        strip_prefix = "confidential-computing.tee.dcap-DCAP_1.23",
+        sha256 = "9284ac7223f72daaeed8fb3c5bb3e4b1ccee6c2deafd0e7398c95c9fa50ffe8a",
     )
 
 def _com_gitee_hygon_csv_header():

--- a/trustflow/attestation/collateral/BUILD.bazel
+++ b/trustflow/attestation/collateral/BUILD.bazel
@@ -22,6 +22,7 @@ trustflow_cc_library(
     hdrs = ["intel_collateral.h"],
     deps = [
         "//trustflow/attestation/utils:json2pb",
+        "//trustflow/attestation/utils:bin2str",
         "@dcap//:sgx_dcap_quoteverify",
         "@sf_apis//:cc_sf_apis_proto",
         "@yacl//yacl/base:exception",

--- a/trustflow/attestation/collateral/intel_collateral.cc
+++ b/trustflow/attestation/collateral/intel_collateral.cc
@@ -64,7 +64,7 @@ void GetIntelCollateral(
   std::string root_ca_crl;
   utils::CharArrayBinaryToEscapedString(reinterpret_cast<const uint8_t*>(p_collateral_t->root_ca_crl),
                    p_collateral_t->root_ca_crl_size, root_ca_crl);
-  collateral.set_root_ca_crl(std::move(root_ca_crl)); 
+  collateral.set_root_ca_crl(std::move(root_ca_crl));
 
   std::string pck_crl;
   utils::CharArrayBinaryToEscapedString(reinterpret_cast<const uint8_t*>(p_collateral_t->pck_crl), p_collateral_t->pck_crl_size, pck_crl);

--- a/trustflow/attestation/collateral/intel_collateral.cc
+++ b/trustflow/attestation/collateral/intel_collateral.cc
@@ -19,6 +19,7 @@
 #include "yacl/base/exception.h"
 
 #include "trustflow/attestation/utils/json2pb.h"
+#include "trustflow/attestation/utils/bin2str.h"
 
 namespace trustflow {
 namespace attestation {
@@ -61,13 +62,12 @@ void GetIntelCollateral(
   collateral.set_pck_crl_issuer_chain(std::move(pck_crl_issuer_chain));
 
   std::string root_ca_crl;
-  CharArray2String(p_collateral_t->root_ca_crl,
+  utils::CharArrayBinaryToEscapedString(reinterpret_cast<const uint8_t*>(p_collateral_t->root_ca_crl),
                    p_collateral_t->root_ca_crl_size, root_ca_crl);
-  collateral.set_root_ca_crl(std::move(root_ca_crl));
+  collateral.set_root_ca_crl(std::move(root_ca_crl)); 
 
   std::string pck_crl;
-  CharArray2String(p_collateral_t->pck_crl, p_collateral_t->pck_crl_size,
-                   pck_crl);
+  utils::CharArrayBinaryToEscapedString(reinterpret_cast<const uint8_t*>(p_collateral_t->pck_crl), p_collateral_t->pck_crl_size, pck_crl);
   collateral.set_pck_crl(std::move(pck_crl));
 
   std::string tcb_info_issuer_chain;

--- a/trustflow/attestation/utils/BUILD.bazel
+++ b/trustflow/attestation/utils/BUILD.bazel
@@ -24,3 +24,8 @@ trustflow_cc_library(
         "@yacl//yacl/base:exception",
     ],
 )
+
+trustflow_cc_library(
+    name = "bin2str",
+    hdrs = ["bin2str.h"],
+)

--- a/trustflow/attestation/utils/bin2str.h
+++ b/trustflow/attestation/utils/bin2str.h
@@ -1,0 +1,97 @@
+// Copyright 2025 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace trustflow {
+namespace attestation {
+namespace utils {
+
+// Convert binary (as char array) to UTF-8 escaped string as std::string.
+// - ASCII printable characters (0x20-0x7E): used as-is (except \ and " which are escaped)
+// - Control characters (0x00-0x1F): escaped as \uXXXX
+// - Non-ASCII bytes (0x80-0xFF): escaped as \uXXXX
+// This allows non-UTF-8 bytes to be stored in protobuf string fields.
+//
+// Note: The format of Intel's PCS Collateral CRLs are determined by the collateral version.
+//       Collateral version 1.0 (PCS/PCCS API V1 or V2): PEM (string)
+//       Collateral version 3.0 (PCS/PCCS API V3): Base16 encoded DER (hex string)
+//       Collateral version 3.1 (PCS/PCCS API V3): Raw binary DER (binary data)
+inline void CharArrayBinaryToEscapedString(const uint8_t* data, size_t size, std::string& result) {
+  result.reserve(size * 6);  // Worst case: each byte becomes \uXXXX (6 chars)
+  
+  for (size_t i = 0; i < size; ++i) {
+    uint8_t byte = data[i];
+    
+    if (byte == 0x00) {
+      // Null byte: escape as \u0000
+      result += "\\u0000";
+    } else if (byte >= 0x20 && byte < 0x7F) {
+      // ASCII printable (except control chars): use as-is
+      // Escape special JSON characters
+      if (byte == '\\' || byte == '"') {
+        result += '\\';
+        result += static_cast<char>(byte);
+      } else {
+        result += static_cast<char>(byte);
+      }
+    } else {
+      // Control characters (0x01-0x1F) and non-ASCII bytes (0x80-0xFF): escape as \uXXXX
+      char hex[7];
+      snprintf(hex, sizeof(hex), "\\u%04X", static_cast<unsigned int>(byte));
+      result += hex;
+    }
+  }
+}
+
+// Convert escaped string (\uXXXX sequences) back to binary (as char array).
+inline std::vector<uint8_t> EscapedStringToCharArrayBinary(const std::string& escaped_str) {
+  std::vector<uint8_t> binary;
+  binary.reserve(escaped_str.size());  // Approximate size
+  
+  for (size_t i = 0; i < escaped_str.size(); ++i) {
+    if (escaped_str[i] == '\\' && i + 1 < escaped_str.size()) {
+      if (escaped_str[i + 1] == 'u' && i + 5 < escaped_str.size()) {
+        // \uXXXX sequence (6 chars: \uXXXX)
+        std::string hex = escaped_str.substr(i + 2, 4);
+        char* endptr = nullptr;
+        unsigned long val = std::strtoul(hex.c_str(), &endptr, 16);
+        if (endptr == hex.c_str() + 4 && val <= 0xFF) {
+          binary.push_back(static_cast<uint8_t>(val));
+          i += 5;  // Skip \uXXXX (6 chars total: i, i+1, i+2, i+3, i+4, i+5)
+          continue;
+        }
+      } else if (escaped_str[i + 1] == '\\' || escaped_str[i + 1] == '"') {
+        // Escaped backslash or quote
+        binary.push_back(static_cast<uint8_t>(escaped_str[i + 1]));
+        i += 1;  // Skip escape char
+        continue;
+      }
+      // If escape sequence is not recognized, treat backslash as regular character
+    }
+    // Regular character
+    binary.push_back(static_cast<uint8_t>(escaped_str[i]));
+  }
+  
+  return binary;
+}
+
+}  // namespace utils
+}  // namespace attestation
+}  // namespace trustflow

--- a/trustflow/attestation/utils/bin2str.h
+++ b/trustflow/attestation/utils/bin2str.h
@@ -34,16 +34,14 @@ namespace utils {
 //       Collateral version 3.0 (PCS/PCCS API V3): Base16 encoded DER (hex string)
 //       Collateral version 3.1 (PCS/PCCS API V3): Raw binary DER (binary data)
 inline void CharArrayBinaryToEscapedString(const uint8_t* data, size_t size, std::string& result) {
+  result.clear();
   result.reserve(size * 6);  // Worst case: each byte becomes \uXXXX (6 chars)
   
   for (size_t i = 0; i < size; ++i) {
     uint8_t byte = data[i];
     
-    if (byte == 0x00) {
-      // Null byte: escape as \u0000
-      result += "\\u0000";
-    } else if (byte >= 0x20 && byte < 0x7F) {
-      // ASCII printable (except control chars): use as-is
+    if (byte >= 0x20 && byte <= 0x7E) {
+      // ASCII printable characters: use as-is
       // Escape special JSON characters
       if (byte == '\\' || byte == '"') {
         result += '\\';
@@ -52,7 +50,7 @@ inline void CharArrayBinaryToEscapedString(const uint8_t* data, size_t size, std
         result += static_cast<char>(byte);
       }
     } else {
-      // Control characters (0x01-0x1F) and non-ASCII bytes (0x80-0xFF): escape as \uXXXX
+      // Control characters (0x00-0x1F), DEL (0x7F), and non-ASCII bytes (0x80-0xFF): escape as \uXXXX
       char hex[7];
       snprintf(hex, sizeof(hex), "\\u%04X", static_cast<unsigned int>(byte));
       result += hex;
@@ -61,9 +59,10 @@ inline void CharArrayBinaryToEscapedString(const uint8_t* data, size_t size, std
 }
 
 // Convert escaped string (\uXXXX sequences) back to binary (as char array).
-inline std::vector<uint8_t> EscapedStringToCharArrayBinary(const std::string& escaped_str) {
+// If add_null_terminator is true, appends a null byte at the end for C string compatibility.
+inline std::vector<uint8_t> EscapedStringToCharArrayBinary(const std::string& escaped_str, bool add_null_terminator = false) {
   std::vector<uint8_t> binary;
-  binary.reserve(escaped_str.size());  // Approximate size
+  binary.reserve(escaped_str.size() + (add_null_terminator ? 1 : 0));  // Approximate size
   
   for (size_t i = 0; i < escaped_str.size(); ++i) {
     if (escaped_str[i] == '\\' && i + 1 < escaped_str.size()) {
@@ -87,6 +86,10 @@ inline std::vector<uint8_t> EscapedStringToCharArrayBinary(const std::string& es
     }
     // Regular character
     binary.push_back(static_cast<uint8_t>(escaped_str[i]));
+  }
+  
+  if (add_null_terminator) {
+    binary.push_back(0);  // Add null terminator
   }
   
   return binary;

--- a/trustflow/attestation/verification/sgx2/BUILD.bazel
+++ b/trustflow/attestation/verification/sgx2/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
     hdrs = ["sgx2_verifier.h"],
     deps = [
         "//trustflow/attestation/common:constants",
+        "//trustflow/attestation/utils:bin2str",
         "//trustflow/attestation/verification/interface:verifier",
         "@cppcodec",
         "@dcap//:sgx_dcap_quoteverify",

--- a/trustflow/attestation/verification/sgx2/sgx2_verifier.cc
+++ b/trustflow/attestation/verification/sgx2/sgx2_verifier.cc
@@ -24,6 +24,7 @@
 
 #include "trustflow/attestation/common/constants.h"
 #include "trustflow/attestation/utils/json2pb.h"
+#include "trustflow/attestation/utils/bin2str.h"
 
 namespace trustflow {
 namespace attestation {
@@ -45,6 +46,31 @@ inline void SetCollateral(const std::string& name, const std::string& value,
   *length = value.size() + 1;
 }
 
+inline void SetCollateral(const std::string& name, const std::vector<uint8_t>& value,
+                          char** dest, uint32_t* length) {
+  YACL_ENFORCE(!value.empty(), "Invlaid collateral data: {}", name);
+  // Allocate memory for decoded data (with null terminator for qvl compatibility)
+  char* decoded_data = static_cast<char*>(malloc(value.size() + 1));
+  YACL_ENFORCE(decoded_data != nullptr, "Failed to allocate memory for {}", name);
+  memcpy(decoded_data, value.data(), value.size());
+  decoded_data[value.size()] = '\0';
+  *dest = decoded_data;
+  *length = value.size() + 1;
+}
+
+inline void SetCollateralFromEscapedString(const std::string& name, const std::string& escaped_value,
+                      char** dest, uint32_t* length) {
+  YACL_ENFORCE(!escaped_value.empty(), "Invalid collateral data: {}", name);
+  
+  std::vector<uint8_t> decoded = utils::EscapedStringToCharArrayBinary(escaped_value);
+  if (decoded.empty()) {
+    YACL_THROW("Failed to decode escaped string for {}", name);
+  }
+  
+  SetCollateral(name, decoded, dest, length);
+}
+
+
 void InitializeCollateralData(const ual::SgxQlQveCollateral& collateral,
                               sgx_ql_qve_collateral_t* collateral_data) {
   collateral_data->version = collateral.version();
@@ -52,10 +78,10 @@ void InitializeCollateralData(const ual::SgxQlQveCollateral& collateral,
   SetCollateral("pck_crl_issuer_chain", collateral.pck_crl_issuer_chain(),
                 &(collateral_data->pck_crl_issuer_chain),
                 &(collateral_data->pck_crl_issuer_chain_size));
-  SetCollateral("root_ca_crl", collateral.root_ca_crl(),
+  SetCollateralFromEscapedString("root_ca_crl", collateral.root_ca_crl(),
                 &(collateral_data->root_ca_crl),
-                &(collateral_data->root_ca_crl_size));
-  SetCollateral("pck_crl", collateral.pck_crl(), &(collateral_data->pck_crl),
+                &(collateral_data->root_ca_crl_size));  
+  SetCollateralFromEscapedString("pck_crl", collateral.pck_crl(), &(collateral_data->pck_crl),
                 &(collateral_data->pck_crl_size));
   SetCollateral("tcb_info_issuer_chain", collateral.tcb_info_issuer_chain(),
                 &(collateral_data->tcb_info_issuer_chain),

--- a/trustflow/attestation/verification/sgx2/sgx2_verifier.cc
+++ b/trustflow/attestation/verification/sgx2/sgx2_verifier.cc
@@ -38,7 +38,7 @@ namespace ual = secretflowapis::v2::sdc;
 
 inline void SetCollateral(const std::string& name, const std::string& value,
                           char** dest, uint32_t* length) {
-  YACL_ENFORCE(!value.empty(), "Invlaid collateral data: {}", name);
+  YACL_ENFORCE(!value.empty(), "Invalid collateral data: {}", name);
   *dest = const_cast<char*>(value.data());
   // +1 is the workaround for the code in qvl, size should include the end '\0'
   // #define IS_IN_ENCLAVE_POINTER(p, size)
@@ -48,40 +48,38 @@ inline void SetCollateral(const std::string& name, const std::string& value,
 
 inline void SetCollateral(const std::string& name, const std::vector<uint8_t>& value,
                           char** dest, uint32_t* length) {
-  YACL_ENFORCE(!value.empty(), "Invlaid collateral data: {}", name);
-  // Allocate memory for decoded data (with null terminator for qvl compatibility)
-  char* decoded_data = static_cast<char*>(malloc(value.size() + 1));
-  YACL_ENFORCE(decoded_data != nullptr, "Failed to allocate memory for {}", name);
-  memcpy(decoded_data, value.data(), value.size());
-  decoded_data[value.size()] = '\0';
-  *dest = decoded_data;
-  *length = value.size() + 1;
+  YACL_ENFORCE(!value.empty(), "Invalid collateral data: {}", name);
+  *dest = reinterpret_cast<char*>(const_cast<uint8_t*>(value.data()));
+  *length = value.size();
 }
 
 inline void SetCollateralFromEscapedString(const std::string& name, const std::string& escaped_value,
-                      char** dest, uint32_t* length) {
+                      std::vector<uint8_t>& storage, char** dest, uint32_t* length) {
   YACL_ENFORCE(!escaped_value.empty(), "Invalid collateral data: {}", name);
-  
-  std::vector<uint8_t> decoded = utils::EscapedStringToCharArrayBinary(escaped_value);
-  if (decoded.empty()) {
+  storage = utils::EscapedStringToCharArrayBinary(escaped_value, true);
+  if (storage.empty()) {
     YACL_THROW("Failed to decode escaped string for {}", name);
   }
-  
-  SetCollateral(name, decoded, dest, length);
+  *dest = reinterpret_cast<char*>(storage.data());
+  *length = storage.size();
 }
 
-
 void InitializeCollateralData(const ual::SgxQlQveCollateral& collateral,
-                              sgx_ql_qve_collateral_t* collateral_data) {
+                              sgx_ql_qve_collateral_t* collateral_data,
+                              std::vector<uint8_t>& root_ca_crl_storage,
+                              std::vector<uint8_t>& pck_crl_storage) {
   collateral_data->version = collateral.version();
   // Set the sgx_ql_qve_collateral_t with data pointer and size
   SetCollateral("pck_crl_issuer_chain", collateral.pck_crl_issuer_chain(),
                 &(collateral_data->pck_crl_issuer_chain),
                 &(collateral_data->pck_crl_issuer_chain_size));
   SetCollateralFromEscapedString("root_ca_crl", collateral.root_ca_crl(),
+                root_ca_crl_storage,
                 &(collateral_data->root_ca_crl),
-                &(collateral_data->root_ca_crl_size));  
-  SetCollateralFromEscapedString("pck_crl", collateral.pck_crl(), &(collateral_data->pck_crl),
+                &(collateral_data->root_ca_crl_size));
+  SetCollateralFromEscapedString("pck_crl", collateral.pck_crl(),
+                pck_crl_storage,
+                &(collateral_data->pck_crl),
                 &(collateral_data->pck_crl_size));
   SetCollateral("tcb_info_issuer_chain", collateral.tcb_info_issuer_chain(),
                 &(collateral_data->tcb_info_issuer_chain),
@@ -177,8 +175,12 @@ void Sgx2AttestationVerifier::ParseUnifiedReport(
 }
 
 void Sgx2AttestationVerifier::VerifyPlatform() {
+  // Storage for binary CRL data (with null terminators)
+  std::vector<uint8_t> root_ca_crl_storage;
+  std::vector<uint8_t> pck_crl_storage;
+  
   sgx_ql_qve_collateral_t collateral_data;
-  InitializeCollateralData(collateral_, &collateral_data);
+  InitializeCollateralData(collateral_, &collateral_data, root_ca_crl_storage, pck_crl_storage);
 
   // get supplemental data size
   uint32_t supplemental_data_size = 0;

--- a/trustflow/attestation/verification/tdx/BUILD.bazel
+++ b/trustflow/attestation/verification/tdx/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
     hdrs = ["tdx_verifier.h"],
     deps = [
         "//trustflow/attestation/common:constants",
+        "//trustflow/attestation/utils:bin2str",
         "//trustflow/attestation/verification/interface:verifier",
         "@cppcodec",
         "@dcap//:sgx_dcap_quoteverify",

--- a/trustflow/attestation/verification/tdx/tdx_verifier.cc
+++ b/trustflow/attestation/verification/tdx/tdx_verifier.cc
@@ -25,6 +25,7 @@
 
 #include "trustflow/attestation/common/constants.h"
 #include "trustflow/attestation/utils/json2pb.h"
+#include "trustflow/attestation/utils/bin2str.h"
 
 namespace trustflow {
 namespace attestation {
@@ -49,6 +50,30 @@ inline void SetCollateral(const std::string& name, const std::string& value,
   *length = value.size() + 1;
 }
 
+inline void SetCollateral(const std::string& name, const std::vector<uint8_t>& value,
+                          char** dest, uint32_t* length) {
+  YACL_ENFORCE(!value.empty(), "Invlaid collateral data: {}", name);
+  // Allocate memory for decoded data (with null terminator for qvl compatibility)
+  char* decoded_data = static_cast<char*>(malloc(value.size() + 1));
+  YACL_ENFORCE(decoded_data != nullptr, "Failed to allocate memory for {}", name);
+  memcpy(decoded_data, value.data(), value.size());
+  decoded_data[value.size()] = '\0';
+  *dest = decoded_data;
+  *length = value.size() + 1;
+}
+
+inline void SetCollateralFromEscapedString(const std::string& name, const std::string& escaped_value,
+                      char** dest, uint32_t* length) {
+  YACL_ENFORCE(!escaped_value.empty(), "Invalid collateral data: {}", name);
+  
+  std::vector<uint8_t> decoded = utils::EscapedStringToCharArrayBinary(escaped_value);
+  if (decoded.empty()) {
+    YACL_THROW("Failed to decode escaped string for {}", name);
+  }
+  
+  SetCollateral(name, decoded, dest, length);
+}
+
 void InitializeCollateralData(const ual::SgxQlQveCollateral& collateral,
                               sgx_ql_qve_collateral_t* collateral_data) {
   collateral_data->version = collateral.version();
@@ -56,10 +81,10 @@ void InitializeCollateralData(const ual::SgxQlQveCollateral& collateral,
   SetCollateral("pck_crl_issuer_chain", collateral.pck_crl_issuer_chain(),
                 &(collateral_data->pck_crl_issuer_chain),
                 &(collateral_data->pck_crl_issuer_chain_size));
-  SetCollateral("root_ca_crl", collateral.root_ca_crl(),
+  SetCollateralFromEscapedString("root_ca_crl", collateral.root_ca_crl(),
                 &(collateral_data->root_ca_crl),
                 &(collateral_data->root_ca_crl_size));
-  SetCollateral("pck_crl", collateral.pck_crl(), &(collateral_data->pck_crl),
+  SetCollateralFromEscapedString("pck_crl", collateral.pck_crl(), &(collateral_data->pck_crl),
                 &(collateral_data->pck_crl_size));
   SetCollateral("tcb_info_issuer_chain", collateral.tcb_info_issuer_chain(),
                 &(collateral_data->tcb_info_issuer_chain),

--- a/trustflow/attestation/verification/tdx/tdx_verifier.cc
+++ b/trustflow/attestation/verification/tdx/tdx_verifier.cc
@@ -44,7 +44,7 @@ namespace ual = secretflowapis::v2::sdc;
 
 inline void SetCollateral(const std::string& name, const std::string& value,
                           char** dest, uint32_t* length) {
-  YACL_ENFORCE(!value.empty(), "Invlaid collateral data: {}", name);
+  YACL_ENFORCE(!value.empty(), "Invalid collateral data: {}", name);
   *dest = const_cast<char*>(value.data());
   // +1 is the workaround for the code in qvl, size should include the end '\0'
   *length = value.size() + 1;
@@ -52,39 +52,38 @@ inline void SetCollateral(const std::string& name, const std::string& value,
 
 inline void SetCollateral(const std::string& name, const std::vector<uint8_t>& value,
                           char** dest, uint32_t* length) {
-  YACL_ENFORCE(!value.empty(), "Invlaid collateral data: {}", name);
-  // Allocate memory for decoded data (with null terminator for qvl compatibility)
-  char* decoded_data = static_cast<char*>(malloc(value.size() + 1));
-  YACL_ENFORCE(decoded_data != nullptr, "Failed to allocate memory for {}", name);
-  memcpy(decoded_data, value.data(), value.size());
-  decoded_data[value.size()] = '\0';
-  *dest = decoded_data;
-  *length = value.size() + 1;
+  YACL_ENFORCE(!value.empty(), "Invalid collateral data: {}", name);
+  *dest = reinterpret_cast<char*>(const_cast<uint8_t*>(value.data()));
+  *length = value.size();
 }
 
 inline void SetCollateralFromEscapedString(const std::string& name, const std::string& escaped_value,
-                      char** dest, uint32_t* length) {
+                      std::vector<uint8_t>& storage, char** dest, uint32_t* length) {
   YACL_ENFORCE(!escaped_value.empty(), "Invalid collateral data: {}", name);
-  
-  std::vector<uint8_t> decoded = utils::EscapedStringToCharArrayBinary(escaped_value);
-  if (decoded.empty()) {
+  storage = utils::EscapedStringToCharArrayBinary(escaped_value, true);
+  if (storage.empty()) {
     YACL_THROW("Failed to decode escaped string for {}", name);
   }
-  
-  SetCollateral(name, decoded, dest, length);
+  *dest = reinterpret_cast<char*>(storage.data());
+  *length = storage.size();
 }
 
 void InitializeCollateralData(const ual::SgxQlQveCollateral& collateral,
-                              sgx_ql_qve_collateral_t* collateral_data) {
+                              sgx_ql_qve_collateral_t* collateral_data,
+                              std::vector<uint8_t>& root_ca_crl_storage,
+                              std::vector<uint8_t>& pck_crl_storage) {
   collateral_data->version = collateral.version();
   // Set the sgx_ql_qve_collateral_t with data pointer and size
   SetCollateral("pck_crl_issuer_chain", collateral.pck_crl_issuer_chain(),
                 &(collateral_data->pck_crl_issuer_chain),
                 &(collateral_data->pck_crl_issuer_chain_size));
   SetCollateralFromEscapedString("root_ca_crl", collateral.root_ca_crl(),
+                root_ca_crl_storage,
                 &(collateral_data->root_ca_crl),
                 &(collateral_data->root_ca_crl_size));
-  SetCollateralFromEscapedString("pck_crl", collateral.pck_crl(), &(collateral_data->pck_crl),
+  SetCollateralFromEscapedString("pck_crl", collateral.pck_crl(),
+                pck_crl_storage,
+                &(collateral_data->pck_crl),
                 &(collateral_data->pck_crl_size));
   SetCollateral("tcb_info_issuer_chain", collateral.tcb_info_issuer_chain(),
                 &(collateral_data->tcb_info_issuer_chain),
@@ -220,8 +219,12 @@ void TdxAttestationVerifier::ParseUnifiedReport(
 }
 
 void TdxAttestationVerifier::VerifyPlatform() {
+  // Storage for binary CRL data (with null terminators)
+  std::vector<uint8_t> root_ca_crl_storage;
+  std::vector<uint8_t> pck_crl_storage;
+  
   sgx_ql_qve_collateral_t collateral_data;
-  InitializeCollateralData(collateral_, &collateral_data);
+  InitializeCollateralData(collateral_, &collateral_data, root_ca_crl_storage, pck_crl_storage);
 
   // get supplemental data size
   uint32_t supplemental_data_size = 0;


### PR DESCRIPTION
This PR supersedes #114 and #115.

The previous PRs were partial changes and could not completely fix the errors involving SGX2/TDX. This PR integrates the following:
1. #114
   - See the original PR for details.
2. #115
   - See the original PR for details.
3. DCAP Collateral v3.1+ binary CRL support
   - The format of the CRLs fetched from Intel PCS/PCCS varies depending on the `version` field of the `sgx_ql_qve_collateral_t` struct.
     * V1 and V2 APIs: version = 1.0 → CRLs formatted in PEM (string)
     * V3 API: version = 3.0 → CRLs formatted in Base16 DER (string)
     * V3 API: version = 3.1 → CRLs formatted in raw binary DER
   - Currently, the implementation only supports CRLs that can be interpreted as UTF-8 strings (i.e., versions 1.0 and 3.0). 
     If a raw binary DER CRL (version 3.1) is returned, protobuf serialization/deserialization fails due to non-UTF-8 bytes.
   - This change adjusts the (de)serialisation logic to correctly handle version 3.1 CRLs, ensuring that Root CA and PCK CRLs in SGX2/TDX environments are properly read.
   - Reference: Section 3.3.1.6 (p.23) in [Intel SGX DCAP: ECDSA Quote Library API (v1.20)](https://download.01.org/intel-sgx/sgx-dcap/1.20/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf)

These three changes together enable correct operation in modern SGX2/TDX environments.

### Note (added on 21 Nov UTC)
This PR applies a minimal workaround to safely handle raw DER CRLs that are not valid UTF-8. The underlying issue is that the [current SecretFlow API model](https://github.com/secretflow/secure-data-capsule-apis/blob/549bfb96868f00045444841ca51817098c4f9584/secretflowapis/v2/sdc/ual.proto) defines CRL fields (`root_ca_crl` and `pck_crl` in `SgxQlQveCollateral`) as `string`, while DCAP v3.1+ may return CRLs in raw binary DER format.

In the future, it may be preferable to change CRL-related fields in the API to `bytes`. This change would remain backward-compatible, since existing UTF-8 strings can be losslessly represented as `bytes` and reserialised. That said, I fully understand that API-level changes must be conservative and cannot be applied immediately. Therefore, this PR keeps its scope limited to the smallest safe workaround, without attempting to modify the API itself.